### PR TITLE
feat: mount ragpipe system prompt from host filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ cp ragstack.env.example ~/.config/llm-stack/ragstack.env
   uninstall       remove quadlets (models kept)
 ```
 
+## Configuration
+
+### System prompt
+
+The ragpipe system prompt controls how the model cites documents and when it falls back to general knowledge. It is mounted from the host at runtime — no image rebuild required.
+
+- **Location**: `~/.config/ragpipe/system-prompt.txt`
+- **First install**: automatically copied from `config/ragpipe/system-prompt.txt` during `./llm-stack.sh setup`
+- **Changing it**: edit `~/.config/ragpipe/system-prompt.txt` and restart ragpipe: `systemctl --user restart ragpipe`
+- **Hot reload**: `curl -X POST http://localhost:8090/admin/reload-prompt -H "Authorization: Bearer $RAGPIPE_ADMIN_TOKEN"` — no restart needed
+
+For the grounding rules this implements, see [Grounding](docs/grounding.md).
+
 ## Claude Code integration
 
 Point Claude Code at the LiteLLM proxy:

--- a/config/ragpipe/system-prompt.txt
+++ b/config/ragpipe/system-prompt.txt
@@ -1,0 +1,11 @@
+You are a knowledgeable assistant with access to a curated document corpus. Use the following rules when answering:
+
+1. If the retrieved documents contain relevant information, use them as your primary source. Each document chunk is labeled with (from: "Title") so you can identify it. In your prose, refer to documents by their human-readable title (e.g., "According to your Resume...", "Based on your contacts..."). However, you MUST also include [doc_id:chunk_id] citation markers for every claim to enable validation. The [doc_id:chunk_id] marker must appear even when you reference the document by title in prose. Answer directly from the document content — do not second-guess what the document is. If the text says it is a particular law, act, or report, treat it as that document.
+
+2. Only use the "⚠️ Not in corpus:" prefix when NONE of the retrieved documents are relevant to the question. If you cite even one document, do NOT start with or include "⚠️ Not in corpus:" — the answer IS from the corpus. Partial coverage is still corpus coverage.
+
+3. If the retrieved documents partially answer the question, answer the covered portion from documents with citations first. You may then add supplementary context from general knowledge, clearly separated and prefixed with "⚠️ Not in corpus:" for that portion only.
+
+4. Never present general knowledge as if it came from the retrieved documents. Never fabricate citations.
+
+5. If you are uncertain whether your general knowledge is accurate, say so explicitly rather than stating it with false confidence.

--- a/llm-stack.sh
+++ b/llm-stack.sh
@@ -294,6 +294,15 @@ cmd_setup() {
     cp "$SCRIPT_DIR/configs/litellm-config.yaml" "$CONFIG_DIR/litellm-config.yaml"
     ok "Copied litellm-config.yaml"
 
+    # ragpipe system prompt — operator-editable without rebuilding the image
+    mkdir -p "$HOME/.config/ragpipe"
+    if [[ ! -f "$HOME/.config/ragpipe/system-prompt.txt" ]]; then
+        cp "$SCRIPT_DIR/config/ragpipe/system-prompt.txt" "$HOME/.config/ragpipe/system-prompt.txt"
+        ok "Copied system-prompt.txt — edit ~/.config/ragpipe/system-prompt.txt to customize"
+    else
+        ok "ragpipe system prompt already present"
+    fi
+
     if [[ "$GPU_VENDOR" != "nvidia" ]]; then
         if ! grep -q 'HSA_OVERRIDE_GFX_VERSION' "$HOME/.bashrc" 2>/dev/null; then
             printf '\n# LLM Stack — AMD ROCm\nexport HSA_OVERRIDE_GFX_VERSION=11.5.1\n' \

--- a/quadlets/ragpipe.container
+++ b/quadlets/ragpipe.container
@@ -20,6 +20,11 @@ Volume=ragpipe-model-cache:/home/default/.cache/ragpipe:Z
 # Routes config (local file, not in repo)
 Volume=%h/.config/ragpipe/routes.yaml:/etc/ragpipe/routes.yaml:ro,Z
 
+# System prompt — edit ~/.config/ragpipe/system-prompt.txt to change model
+# citation behavior without rebuilding the image. First-run setup copies this
+# from config/ragpipe/system-prompt.txt if not already present.
+Volume=%h/.config/ragpipe/system-prompt.txt:/etc/ragpipe/system-prompt.txt:ro,Z
+
 # Run as non-root user (default in UBI Python images, UID 1001)
 User=1001
 
@@ -34,6 +39,9 @@ EnvironmentFile=%h/.config/llm-stack/ragstack.env
 # Semantic router — optional, ragpipe works without RAGPIPE_ROUTES_FILE
 # Create ~/.config/ragpipe/routes.yaml to enable routing (see ragpipe docs)
 Environment=RAGPIPE_ROUTES_FILE=/etc/ragpipe/routes.yaml
+
+# System prompt — loaded from file by ragpipe on startup
+Environment=RAGPIPE_SYSTEM_PROMPT_FILE=/etc/ragpipe/system-prompt.txt
 
 # Override ragpipe defaults for wider retrieval window (default: 20/5)
 Environment=RAG_TOP_K=40


### PR DESCRIPTION
## Summary

Mount the ragpipe system prompt from a host file instead of baking it into the image. Enables operators to customize citation behavior without rebuilding the container.

## Changes

- **quadlets/ragpipe.container**: Add `Volume=` mount for `~/.config/ragpipe/system-prompt.txt` and `Environment=RAGPIPE_SYSTEM_PROMPT_FILE=/etc/ragpipe/system-prompt.txt`
- **config/ragpipe/system-prompt.txt**: New file with the approved corpus-preferring grounding prompt
- **llm-stack.sh**: Add setup step to copy `config/ragpipe/system-prompt.txt` to `~/.config/ragpipe/system-prompt.txt` on first run (only if not already present)
- **README.md**: Document that operators can customize the system prompt by editing `~/.config/ragpipe/system-prompt.txt` and either restarting ragpipe or calling `POST /admin/reload-prompt`

## Audit findings

The running system already has this mount configured locally (`~/.config/containers/systemd/ragpipe.container`). This change commits that configuration to the repo so it survives reinstalls and is visible to other operators.