### PR TITLE
fix: add short identity query utterances to personnel route

### DIFF
--- a/config/ragpipe/routes.yaml
+++ b/config/ragpipe/routes.yaml
@@ -1,0 +1,63 @@
+threshold: 0.3
+fallback_route: general
+
+routes:
+  analysis:
+    examples:
+      - "Summarize the key provisions of the defense authorization act"
+      - "Compare the strategies presented for sovereign AI"
+      - "What are the implications of this policy for NATO allies?"
+      - "Analyze the relationship between these defense programs"
+      - "Create a comprehensive overview of this topic"
+    model_url: http://host.containers.internal:8080
+    qdrant_url: http://host.containers.internal:6333
+    qdrant_collection: nato
+    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    reranker_top_n: 15
+    top_k: 40
+
+  personnel:
+    examples:
+      - "What is this person's role and background?"
+      - "Create a profile summary for this individual"
+      - "Who is responsible for this program?"
+      - "What are their qualifications and experience?"
+      - "who is adam clater"
+      - "tell me about john smith"
+      - "what do you know about jane doe"
+      - "describe the employee"
+      - "who is the CEO of this company"
+      - "what is john's job title"
+      - "find information about the new hire"
+      - "who is leading the team"
+      - "tell me about the person in the resume"
+      - "what does this individual's profile show"
+      - "who is this candidate and what is their experience"
+    model_url: http://host.containers.internal:8080
+    qdrant_url: http://host.containers.internal:6333
+    qdrant_collection: personnel
+    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    reranker_top_n: 5
+    top_k: 20
+
+  lookup:
+    examples:
+      - "What does the MPEP say about patentability?"
+      - "What section covers cybersecurity requirements?"
+      - "Find the provision about design patents"
+      - "What are the rules for patent examination?"
+    model_url: http://host.containers.internal:8080
+    qdrant_url: http://host.containers.internal:6333
+    qdrant_collection: mpep
+    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    reranker_top_n: 5
+    top_k: 20
+
+  general:
+    examples:
+      - "What is the capital of France?"
+      - "Explain how gravity works"
+      - "What is machine learning?"
+      - "How does TCP/IP work?"
+    model_url: http://host.containers.internal:8080
+    rag_enabled: false

--- a/llm-stack.sh
+++ b/llm-stack.sh
@@ -829,6 +829,25 @@ cmd_install() {
 
     systemctl --user daemon-reload
 
+    # Copy config files (routes.yaml, system-prompt.txt) if not already present
+    mkdir -p "$HOME/.config/ragpipe"
+    if [[ -f "$SCRIPT_DIR/config/ragpipe/routes.yaml" ]]; then
+        if [[ ! -f "$HOME/.config/ragpipe/routes.yaml" ]]; then
+            cp "$SCRIPT_DIR/config/ragpipe/routes.yaml" "$HOME/.config/ragpipe/routes.yaml"
+            ok "Copied routes.yaml to ~/.config/ragpipe/"
+        else
+            log "routes.yaml already exists in ~/.config/ragpipe/, keeping existing"
+        fi
+    fi
+    if [[ -f "$SCRIPT_DIR/config/ragpipe/system-prompt.txt" ]]; then
+        if [[ ! -f "$HOME/.config/ragpipe/system-prompt.txt" ]]; then
+            cp "$SCRIPT_DIR/config/ragpipe/system-prompt.txt" "$HOME/.config/ragpipe/system-prompt.txt"
+            ok "Copied system-prompt.txt to ~/.config/ragpipe/"
+        else
+            log "system-prompt.txt already exists in ~/.config/ragpipe/, keeping existing"
+        fi
+    fi
+
     # Verify generator is happy
     local errors
     errors=$(/usr/lib/systemd/user-generators/podman-user-generator -dryrun -user 2>&1 \


### PR DESCRIPTION
## Summary

Adds 11 new utterances to the personnel route to fix routing for short identity queries like "who is adam clater".

## Changes

- : New file with updated personnel route utterances
- : Copy routes.yaml and system-prompt.txt from config/ to ~/.config/ragpipe/ on first run

## Testing

- Query "who is adam clater" now routes to personnel (score=0.3633)
- Query "who is adam clater job title employer" routes to personnel (score=0.5312)
- Response uses citations correctly without Not in corpus prefix

Note: rag_metadata shows "grounding: general" because the model doesn't use the ⚠️ prefix when citing documents (correct behavior). The response is actually grounded in the retrieved documents.