### PR TITLE
sec: remove hardcoded database credentials from routes.yaml

### DIFF
--- a/config/ragpipe/routes.yaml
+++ b/config/ragpipe/routes.yaml
@@ -12,7 +12,7 @@ routes:
     model_url: http://host.containers.internal:8080
     qdrant_url: http://host.containers.internal:6333
     qdrant_collection: nato
-    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    # docstore_url sourced from DOCSTORE_URL env var (ragstack.env)
     reranker_top_n: 15
     top_k: 40
 
@@ -36,7 +36,7 @@ routes:
     model_url: http://host.containers.internal:8080
     qdrant_url: http://host.containers.internal:6333
     qdrant_collection: personnel
-    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    # docstore_url sourced from DOCSTORE_URL env var (ragstack.env)
     reranker_top_n: 5
     top_k: 20
 
@@ -49,7 +49,7 @@ routes:
     model_url: http://host.containers.internal:8080
     qdrant_url: http://host.containers.internal:6333
     qdrant_collection: mpep
-    docstore_url: postgresql://litellm:litellm@host.containers.internal:5432/litellm
+    # docstore_url sourced from DOCSTORE_URL env var (ragstack.env)
     reranker_top_n: 5
     top_k: 20
 


### PR DESCRIPTION
## Summary
- Remove `docstore_url: postgresql://litellm:litellm@...` from routes.yaml (3 occurrences)
- Ragpipe falls back to `DOCSTORE_URL` env var when `docstore_url` is omitted from route config
- `DOCSTORE_URL` is already set in `ragstack.env` and loaded via `EnvironmentFile` in the quadlet
- No code changes needed — the fallback path is `create_docstore(url=config.docstore_url)` → `url or DOCSTORE_URL` env var

## Flagged by
CodeRabbit review on framework-ai-stack #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)