### PR TITLE
fix(quadlet): add SecurityLabelDisable justification to ramalama (fixes #16)

### DIFF
--- a/quadlets/ramalama.container
+++ b/quadlets/ramalama.container
@@ -14,6 +14,11 @@ Image=quay.io/ramalama/rocm:0.18.0
 # GPU passthrough — /dev/kfd (compute) + /dev/dri (render)
 AddDevice=-/dev/kfd
 AddDevice=-/dev/dri
+# SELinux container_t denies access to /dev/kfd (ROCm compute interface).
+# No upstream SELinux policy module exists for /dev/kfd on Fedora 43.
+# Disabling label confinement is required until ROCm ships an SELinux policy
+# or Fedora adds /dev/kfd to container device access rules.
+# Ref: ADR-011, https://github.com/ROCm/ROCm/issues/3987
 SecurityLabelDisable=true
 
 # GFX version override for AI Max+ 395; remove once ROCm ships gfx1151 support


### PR DESCRIPTION
Closes #16

## Problem
`ramalama.container` has `SecurityLabelDisable=true` without an inline justification comment, violating the documented security policy.

## Solution
Added inline comment explaining:
- SELinux `container_t` denies access to `/dev/kfd` (ROCm compute interface)
- No upstream SELinux policy module exists for `/dev/kfd` on Fedora 43
- References ADR-011 and upstream ROCm issue

## Testing
- 87/87 shell tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)