### PR TITLE
feat(framework-ai-stack): add ragstuffer-mpep quadlet for USPTO patent collection (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Local AI stack for Fedora 43 on the Framework Desktop (Ryzen AI Max+ 395, 128 GB
 | litellm | `ghcr.io/berriai/litellm:main-stable` | 4000 | OpenAI-compatible proxy |
 | open-webui | `ghcr.io/open-webui/open-webui:v0.8.12` | 3000 | Chat UI, pinned to v0.8.12 |
 | ragstuffer | `localhost/ragstuffer:main` | 8091 | Admin API (ingest trigger, metrics) |
+| ragstuffer-mpep | `localhost/ragstuffer:main` | 8093 | USPTO/MPEP patent ingestion |
 | ragwatch | `localhost/ragwatch:main` | 9090 | Prometheus aggregation + /metrics/summary JSON |
 
 Models are pulled and managed by [RamaLama](https://github.com/containers/ramalama). LiteLLM routes all aliases through the ragpipe. The proxy searches Qdrant for candidate vectors (reference payloads only — no text stored in Qdrant), hydrates chunk text from the Postgres document store, reranks with cross-encoder/ms-marco-MiniLM-L-6-v2, and injects the top results as context before forwarding to the model. Documents from Google Drive, git repos, and web URLs are automatically ingested — no model restart required.
@@ -140,7 +141,8 @@ All services expose health endpoints:
 
 ```bash
 curl http://localhost:8090/health   # ragpipe
-curl http://localhost:8091/health   # ragstuffer
+curl http://localhost:8091/health   # ragstuffer (documents collection)
+curl http://localhost:8093/health   # ragstuffer-mpep (mpep collection)
 curl http://localhost:9090/health   # ragwatch (returns "degraded" if upstream is down)
 curl http://localhost:4000/health   # litellm
 curl http://localhost:6333/readyz   # qdrant
@@ -156,6 +158,8 @@ curl http://localhost:8090/metrics
 
 # ragstuffer metrics
 curl http://localhost:8091/metrics
+# ragstuffer-mpep metrics
+curl http://localhost:8093/metrics
 
 # ragwatch aggregated metrics
 curl http://localhost:9090/metrics

--- a/quadlets/ragstuffer-mpep.container
+++ b/quadlets/ragstuffer-mpep.container
@@ -1,0 +1,52 @@
+# ~/.config/containers/systemd/ragstuffer-mpep.container
+# ragstuffer — polls USPTO/MPEP document sources and ingests into Qdrant + Postgres
+# Source: https://github.com/aclater/ragstuffer
+# Managed by: systemctl --user [start|stop|restart|status] ragstuffer-mpep
+
+[Unit]
+Description=ragstuffer-mpep (MPEP patent document ingestion)
+After=local-fs.target network-online.target qdrant.service ragpipe.service
+Wants=network-online.target
+Requires=qdrant.service ragpipe.service
+
+[Container]
+Image=localhost/ragstuffer:main
+
+Volume=%h/git/ragstuffer:/app:ro,z
+Volume=%h/git/ragpipe/ragpipe/docstore.py:/app/docstore.py:ro,z
+Volume=%h/.config/ramalama/gdrive-sa.json:/run/secrets/gdrive-sa.json:ro,z
+Volume=rag-staging:/staging:Z
+
+EnvironmentFile=%h/.config/llm-stack/env
+EnvironmentFile=%h/.config/llm-stack/ragstack.env
+
+Environment=GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gdrive-sa.json
+Environment=STAGING_DIR=/staging
+Environment=QDRANT_URL=http://host.containers.internal:6333
+Environment=QDRANT_COLLECTION=mpep
+Environment=EMBED_URL=http://host.containers.internal:8090/v1/embeddings
+Environment=DOCSTORE_BACKEND=postgres
+Environment=GDRIVE_FOLDER_ID=<mpep-folder-id>
+
+# Admin API for triggering ingestion (POST /admin/ingest-now, /admin/ingest-full)
+Environment=RAGSTUFFER_ADMIN_PORT=8093
+
+Network=host
+
+Exec=python3.12 /app/ragstuffer.py
+
+ContainerName=ragstuffer-mpep
+
+HealthCmd=curl -sf http://127.0.0.1:8093/health
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=60s
+
+[Service]
+Restart=on-failure
+RestartSec=30s
+TimeoutStartSec=300s
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #11

## Problem
Need a second ragstuffer instance configured to ingest USPTO/MPEP patent documents into a separate Qdrant `mpep` collection, distinct from the existing `documents` collection.

## Solution
- Added `quadlets/ragstuffer-mpep.container` — a systemd quadlet for the second ragstuffer instance, configured with:
  - `QDRANT_COLLECTION=mpep`
  - `RAGSTUFFER_ADMIN_PORT=8093`
  - `GDRIVE_FOLDER_ID=<mpep-folder-id>` (placeholder — replace with actual folder ID)
  - `ContainerName=ragstuffer-mpep`
- Updated README.md to document the new service:
  - Added to services table
  - Added health and metrics endpoints

## Prerequisites (human tasks)
- Create dedicated USPTO/MPEP Google Drive folder and note its folder ID
- Replace `<mpep-folder-id>` placeholder in the quadlet with the actual folder ID
- Ensure `mpep` Qdrant collection exists

## Testing
- Quadlet follows exact same structure as existing `ragstuffer.container`
- yamllint and ruff pass on the repo