### PR TITLE
fix(quadlet): configure ragstuffer-mpep with MPEP folder ID (fixes aclater/ragstuffer#11)

### DIFF
--- a/quadlets/ragstuffer-mpep.container
+++ b/quadlets/ragstuffer-mpep.container
@@ -26,7 +26,7 @@ Environment=QDRANT_URL=http://host.containers.internal:6333
 Environment=QDRANT_COLLECTION=mpep
 Environment=EMBED_URL=http://host.containers.internal:8090/v1/embeddings
 Environment=DOCSTORE_BACKEND=postgres
-Environment=GDRIVE_FOLDER_ID=<mpep-folder-id>
+Environment=GDRIVE_FOLDER_ID=1BbOdtp9fj6LdtRWhpe9LA1TmTBvyOkAd
 
 # Admin API for triggering ingestion (POST /admin/ingest-now, /admin/ingest-full)
 Environment=RAGSTUFFER_ADMIN_PORT=8093


### PR DESCRIPTION
Closes aclater/ragstuffer#11

## Problem
ragstuffer-mpep quadlet had `GDRIVE_FOLDER_ID=<mpep-folder-id>` placeholder.

## Solution
- Set `GDRIVE_FOLDER_ID=1BbOdtp9fj6LdtRWhpe9LA1TmTBvyOkAd` (dedicated MPEP folder)
- mpep Qdrant collection already exists
- Quadlet targets port 8093 (separate from main ragstuffer on 8091)

## Before starting the service
Move MPEP PDFs from the main RAG folder to the MPEP folder in Google Drive. The service account has read-only access to the main folder and cannot move files programmatically.

## Testing
- 87/87 shell tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)