### PR TITLE
fix(ramalama): add -dio flag to prevent GTT allocation on gfx1151

### DIFF
--- a/docs/adr/010-uma-memory-configuration.md
+++ b/docs/adr/010-uma-memory-configuration.md
@@ -23,3 +23,39 @@ Set `HSA_OVERRIDE_GFX_VERSION=11.5.1` (required for gfx1151 until ROCm 7.x) and 
 - `LLAMA_HIP_UMA=1` must not be re-added — it is harmful on this hardware with a dedicated VRAM carve-out
 - The `env.example` includes a comment warning against setting it
 - KV cache (q8_0, 1360 MiB) also resides in the GPU memory pool
+
+## Addendum: direct I/O required on gfx1151 (2026-04-05)
+
+Removing `LLAMA_HIP_UMA=1` is necessary but not sufficient. The default
+mmap loading path in llama-server also causes model tensors to land in GTT
+instead of VRAM on gfx1151. This happens because:
+
+1. `rocminfo` reports `VMM: no` for gfx1151 — the ROCm runtime cannot use
+   virtual memory management to map buffers into VRAM directly
+2. `hipMalloc()` can only allocate within the BIOS-carved VRAM region but
+   the mmap path triggers page-locking overhead that stalls or deadlocks
+   for models >6 GB
+3. Without a workaround, the 30 GB model loads into GTT (~32 GB system RAM)
+   with only ~400 MB in actual VRAM, or hangs indefinitely during loading
+
+The `-dio` (direct I/O) flag bypasses mmap entirely by reading the model
+file directly into pre-allocated GPU buffers. This is documented as
+"required for models >6 GB" on Strix Halo hardware in the
+[known-good stack discussion](https://github.com/ggml-org/llama.cpp/discussions/20856).
+
+### Tested results (2026-04-05)
+
+| Configuration | Loading | Gen speed | Notes |
+|--------------|---------|-----------|-------|
+| Default (mmap) | Hangs indefinitely | N/A | Tensors stuck in GTT |
+| `--no-mmap` | Completes | ~28 t/s | Tensors still in GTT, heap read |
+| `-dio` | Completes | ~39 t/s | Direct I/O into GPU buffers |
+
+The `-dio` flag is now set in the ramalama quadlet. See issue #26.
+
+### Related upstream issues
+
+- [ROCm #5944](https://github.com/ROCm/ROCm/issues/5944) — hipMallocManaged not supported on gfx1150/gfx1151
+- [llama.cpp #15018](https://github.com/ggml-org/llama.cpp/issues/15018) — ROCm slow model loading past VRAM boundary on Strix Halo
+- [llama.cpp discussion #20856](https://github.com/ggml-org/llama.cpp/discussions/20856) — Known-good Strix Halo ROCm stack
+- [llamacpp-rocm #57](https://github.com/lemonade-sdk/llamacpp-rocm/issues/57) — hipMalloc only allocates VRAM, not GTT on APU

--- a/quadlets/ramalama.container
+++ b/quadlets/ramalama.container
@@ -31,6 +31,11 @@ Environment=GPU_MAX_HW_QUEUES=1
 Environment=LLAMA_ARG_FLASH_ATTN=1
 Environment=LLAMA_ARG_CACHE_TYPE_K=q4_0
 Environment=LLAMA_ARG_CACHE_TYPE_V=q4_0
+# hipBLASLt kernels — reported 2-3x faster matmul on gfx1151 vs default
+# rocBLAS. No-op if not available in the container build; activates
+# automatically when a future image ships hipBLASLt support.
+# Ref: https://github.com/ggml-org/llama.cpp/issues/13565
+Environment=ROCBLAS_USE_HIPBLASLT=1
 
 # Model bind-mount — RamaLama stores models under ~/.local/share/ramalama
 Mount=type=bind,src=MODEL_PATH_PLACEHOLDER,target=/mnt/models/model.file,ro,Z
@@ -39,9 +44,14 @@ Mount=type=bind,src=MODEL_PATH_PLACEHOLDER,target=/mnt/models/model.file,ro,Z
 # --cache-type-k/v q4_0: halves KV cache vs q8_0, frees ~10GB system RAM
 # --parallel 2: doubles per-slot context (32K), halves KV cache overhead
 # --ctx-size 65536: 32K per slot is sufficient for RAG (typically <8K prompt)
+# -dio: direct I/O — reads model directly into GPU buffers, bypassing mmap.
+#   Required on gfx1151: mmap path hangs during HIP page-locking for models
+#   >6 GB because VMM is not supported (rocminfo VMM: no). Without -dio,
+#   tensors land in GTT (system RAM) instead of VRAM or loading stalls
+#   indefinitely. See ADR-010 and issue #26.
 Exec=llama-server --model /mnt/models/model.file --host 0.0.0.0 --port 8080 \
     --ctx-size 65536 --n-gpu-layers 999 --threads 16 --parallel 2 \
-    --flash-attn on --cache-type-k q4_0 --cache-type-v q4_0 --jinja
+    --flash-attn on --cache-type-k q4_0 --cache-type-v q4_0 -dio --jinja
 
 ContainerName=ramalama
 PublishPort=8080:8080


### PR DESCRIPTION
Closes #26

## Summary
- Add `-dio` (direct I/O) flag to ROCm ramalama quadlet — bypasses mmap loading path that hangs or places model tensors in GTT instead of VRAM on gfx1151
- Add `ROCBLAS_USE_HIPBLASLT=1` env var (no-op today, future-proofs for hipBLASLt-enabled images)
- Update ADR-010 with investigation findings, test results, and upstream references

## Test results

| Configuration | Loading | Gen speed | Notes |
|--------------|---------|-----------|-------|
| Default (mmap) | Hangs indefinitely | N/A | Tensors stuck in GTT |
| `--no-mmap` | Completes | ~28 t/s | Tensors still in GTT |
| **`-dio`** | **Completes** | **~39 t/s** | Direct I/O into GPU buffers |

## Test plan
- [x] `bash tests/run-tests.sh` — 87/87 pass
- [x] Deployed to live harrison stack with `-dio`, confirmed ramalama loads and serves
- [x] Benchmarked generation speed: ~39 t/s (vs ~32 t/s historical VRAM baseline)
- [x] Verified all 6 stack services healthy after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added GPU memory configuration guidance documenting optimization strategies and performance improvements for tensor operations on supported hardware platforms
* Recorded recommended settings and performance benchmarks for optimal system utilization

## Chores
* Updated system configuration with enhanced performance flags for GPU operations and kernel execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->