### PR TITLE
feat(quadlets): add ragwatch.container (refs rag-suite#10)

### DIFF
--- a/quadlets/ragwatch.container
+++ b/quadlets/ragwatch.container
@@ -1,0 +1,40 @@
+# ~/.config/containers/systemd/ragwatch.container
+# ragwatch — observability aggregation for rag-suite (ragpipe + ragstuffer metrics)
+# Source: https://github.com/aclater/ragwatch
+# Managed by: systemctl --user [start|stop|restart|status] ragwatch
+
+[Unit]
+Description=ragwatch — observability aggregation for rag-suite
+After=network-online.target ragpipe.service ragstuffer.service
+
+[Container]
+# Pin digest after first successful build: skopeo inspect docker://ghcr.io/aclater/ragwatch:main
+Image=ghcr.io/aclater/ragwatch:main
+ContainerName=ragwatch
+
+PublishPort=9090:9090
+
+# Credentials from ragstack.env
+EnvironmentFile=%h/.config/llm-stack/ragstack.env
+
+# Health check
+HealthCmd=curl -sf http://127.0.0.1:9090/health
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+HealthStartPeriod=10s
+
+# Security
+NoNewPrivileges=true
+ReadOnlyRootfs=true
+Tmpfs=/tmp
+
+# Networking — needs access to ragpipe and ragstuffer metrics endpoints on host
+Network=host
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Refs aclater/rag-suite#10

## Problem
ragwatch (port 9090) and ragdeck (port 8092) health endpoints return empty — services are not deployed. Root cause: `ragwatch.container` was missing from the `quadlets/` directory, so `llm-stack.sh install` never deployed it.

ragdeck.container already existed — ragdeck's unreachability may be a separate issue (image pull failure, env misconfiguration, etc.) that should be investigated after this fix is deployed.

## Solution
- Added `quadlets/ragwatch.container` following the same pattern as `ragdeck.container`:
  - GHCR image (`ghcr.io/aclater/ragwatch:main`)
  - Host networking for access to ragpipe (:8090) and ragstuffer (:8091) metrics
  - Read-only rootfs, `NoNewPrivileges`, health check
  - `EnvironmentFile` from `ragstack.env`
  - Ordered after `ragpipe.service` and `ragstuffer.service`

## Testing
- `tests/run-tests.sh`: 87 tests passing
- Quadlet file validated against existing patterns (ragdeck, ragstuffer, ragpipe)

## Deployment
After merging, run: `./llm-stack.sh install && systemctl --user start ragwatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added new system service component with automatic startup after network becomes available
* Includes built-in health checks and automatic restart capability on failure
* Implements security hardening measures for enhanced protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->