### PR TITLE
fix(quadlets): replace unsupported ReadOnlyRootfs with ReadOnly (fixes #34)

### DIFF
--- a/quadlets/ragdeck.container
+++ b/quadlets/ragdeck.container
@@ -32,7 +32,7 @@ HealthStartPeriod=15s
 
 # Security
 NoNewPrivileges=true
-ReadOnlyRootfs=true
+ReadOnly=true
 Tmpfs=/tmp
 
 # Networking — needs access to all rag-suite services on host

--- a/quadlets/ragwatch.container
+++ b/quadlets/ragwatch.container
@@ -26,7 +26,7 @@ HealthStartPeriod=10s
 
 # Security
 NoNewPrivileges=true
-ReadOnlyRootfs=true
+ReadOnly=true
 Tmpfs=/tmp
 
 # Networking — needs access to ragpipe and ragstuffer metrics endpoints on host


### PR DESCRIPTION
Closes #34
Refs aclater/rag-suite#10

## Problem
The Podman quadlet generator silently rejects `ReadOnlyRootfs=true` as an unsupported key, causing ragwatch and ragdeck service units to never be generated. This was the root cause of both services being unreachable (rag-suite#10).

```
quadlet-generator: unsupported key 'ReadOnlyRootfs' in group 'Container'
```

## Solution
Replace `ReadOnlyRootfs=true` with `ReadOnly=true` in both `ragwatch.container` and `ragdeck.container`. `ReadOnly` is the correct Podman quadlet key.

## Testing
- `tests/run-tests.sh`: 87 tests passing
- Verified locally: `podman-system-generator --user --dryrun` no longer shows errors for these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container filesystem access control configuration to improve read-only constraint enforcement across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->