### PR TITLE
fix(quadlet): add RAGPIPE_MXR_CACHE, remove forced RAGPIPE_DEVICE (fixes #36)

### DIFF
--- a/quadlets/ragpipe.container
+++ b/quadlets/ragpipe.container
@@ -51,15 +51,17 @@ Environment=RERANKER_TOP_N=15
 Environment=DOCSTORE_BACKEND=postgres
 
 # AMD ROCm GPU access for ONNX Runtime inference (gfx1151)
-# Force MIGraphXExecutionProvider — ROCMExecutionProvider segfaults on gfx1151
-# (RDNA 4 not yet supported by ROCM EP). MIGraphX uses graph-level compilation
-# and handles gfx1151 via HSA_OVERRIDE_GFX_VERSION.
-Environment=RAGPIPE_DEVICE=migraphx
+# Do NOT force RAGPIPE_DEVICE=migraphx — PR #42 added gfx1151 auto-detection
+# that skips MIGraphX when CPU is faster (UMA APUs where tensors land in GTT).
+# Let _get_providers() auto-detect the best provider.
 AddDevice=/dev/kfd
 AddDevice=/dev/dri
 Environment=HSA_OVERRIDE_GFX_VERSION=11.5.1
 # MIOpen JIT-compiles kernels for gfx1151 on first run; cache in writable volume
 Environment=MIOPEN_USER_DB_PATH=/home/default/.cache/ragpipe/miopen
+# MXR cache for ragpipe Python code (models.py reads this env var)
+# Must point inside the writable ragpipe-model-cache volume
+Environment=RAGPIPE_MXR_CACHE=/home/default/.cache/ragpipe/mxr
 # SELinux cannot label /dev/kfd — required for ROCm device access
 # Upstream: https://github.com/ROCm/ROCm/issues/2983
 SecurityLabelDisable=true


### PR DESCRIPTION
Closes #36

## Problem
ragpipe crashed on startup with `PermissionError: Permission denied: /app/.cache`. Two config issues:
1. `RAGPIPE_MXR_CACHE` not set — Python code falls back to `~/.cache/ragpipe/mxr` = `/app/.cache` (not writable)
2. `RAGPIPE_DEVICE=migraphx` overrides PR ragpipe#42 gfx1151 auto-detection

## Solution
- Added `Environment=RAGPIPE_MXR_CACHE=/home/default/.cache/ragpipe/mxr` (inside writable volume)
- Removed forced `RAGPIPE_DEVICE=migraphx` to let auto-detection work

## Testing
- 87 tests passing
- Verified locally: ragpipe starts and serves queries successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GPU device support with automatic provider selection
  * Added performance cache configuration for optimized operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->