### PR TITLE
docs: synchronize documentation with current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Local AI stack for Fedora 43. LLM inference with live RAG from Google Drive, git
 | ragstuffer-mpep | 8093 | ghcr.io/aclater/ragstuffer:main | USPTO/MPEP patent collection |
 | ragwatch | 9090 | ghcr.io/aclater/ragwatch:main | Prometheus aggregation |
 | ragdeck | 8092 | ghcr.io/aclater/ragdeck:main | Admin UI |
-| llama-vulkan | 8080 | localhost/llama-vulkan:b8668 | Qwen3.5-35B-A3B via Vulkan RADV |
+| llama-vulkan | 8080 | ghcr.io/aclater/llama-vulkan:b8668 | Qwen3.5-35B-A3B via Vulkan RADV |
 | qdrant | 6333 | docker.io/qdrant/qdrant:v1.17.1 | Vector search |
 | postgres | 5432 | quay.io/sclorg/postgresql-16-c9s | Document store + LiteLLM state |
 
@@ -73,8 +73,8 @@ ragdeck (:8092) — admin UI for all services
 - Empty retrieval is not an error — model answers from general knowledge with prefix
 - Audit log captures grounding decisions without logging text content
 - LLM inference: Vulkan RADV via llama-vulkan (gfx1151 optimized)
-- MXR cache: cold start ~3:53, warm start ~6s via `ORT_MIGRAPHX_MODEL_CACHE_PATH`
-- Embedder/reranker on CPU (gfx1151): MIGraphX GTT is slower than CPU for small models
+- MXR cache (when MIGraphX path enabled): cold start ~3:53, warm start ~6s via `ORT_MIGRAPHX_MODEL_CACHE_PATH`
+- Embedder/reranker default to CPU on gfx1151: MIGraphX places tensors in GTT (system RAM), making CPU faster for small models
 
 ## Endpoints
 - LiteLLM proxy: http://localhost:4000 (key: sk-llm-stack-local)
@@ -90,6 +90,7 @@ ragdeck (:8092) — admin UI for all services
 ## Health checks
 
 ```bash
+curl http://localhost:8080/health   # llama-vulkan
 curl http://localhost:8090/health   # ragpipe
 curl http://localhost:8091/health   # ragstuffer
 curl http://localhost:8093/health   # ragstuffer-mpep
@@ -134,8 +135,8 @@ RAG document sources configured in `~/.config/llm-stack/ragstack.env`:
 - ROCm 7.x required
 - `HSA_OVERRIDE_GFX_VERSION=11.5.1` required for gfx1151
 - LLM inference: Vulkan RADV via llama-vulkan container (gfx1151 optimized)
-- Embedder/reranker: CPU on gfx1151 — MIGraphX tensors land in GTT instead of VRAM on UMA APUs, CPU is faster for small models
-- **⚠️ Cold start ~3:53**: First boot takes ~3:53 for ONNX model compilation. Warm start (MXR cached): ~6 seconds (39x improvement via `ORT_MIGRAPHX_MODEL_CACHE_PATH`)
+- Embedder/reranker default to CPU on gfx1151 — MIGraphX tensors land in GTT instead of VRAM on UMA APUs, CPU is faster for small models
+- **⚠️ Cold start ~3:53** (when MIGraphX path enabled): first boot takes ~3:53 for ONNX model compilation. Warm start (MXR cached): ~6 seconds via `ORT_MIGRAPHX_MODEL_CACHE_PATH`
 - Reranker (MiniLM-L-6-v2) runs on CPU — this is expected, not a bug
 
 ## Container images
@@ -143,7 +144,7 @@ RAG document sources configured in `~/.config/llm-stack/ragstack.env`:
 - ragstuffer: ghcr.io/aclater/ragstuffer (CPU/ROCm/CUDA variants published to GHCR)
 - ragwatch: ghcr.io/aclater/ragwatch (Prometheus aggregation)
 - ragdeck: ghcr.io/aclater/ragdeck (Admin UI)
-- llama-vulkan: localhost/llama-vulkan (Vulkan RADV for gfx1151)
+- llama-vulkan: ghcr.io/aclater/llama-vulkan (Vulkan RADV for gfx1151)
 - postgres: quay.io/sclorg/postgresql-16-c9s (LiteLLM state + document store)
 - qdrant, litellm, open-webui: upstream images
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Local AI stack for Fedora 43 on the Framework Desktop (Ryzen AI Max+ 395, 128 GB
 |---|---|---|---|
 | postgres | `quay.io/sclorg/postgresql-16-c9s` | 5432 | LiteLLM state + document store |
 | qdrant | `docker.io/qdrant/qdrant:v1.17.1` | 6333 | Vector search (int8 scalar quantization) |
-| llama-vulkan | `localhost/llama-vulkan:b8668` | 8080 | Qwen3.5 via Vulkan RADV (gfx1151 optimized) |
+| llama-vulkan | `ghcr.io/aclater/llama-vulkan:b8668` | 8080 | Qwen3.5 via Vulkan RADV (gfx1151 optimized) |
 | ragpipe | `ghcr.io/aclater/ragpipe:main-rocm` | 8090 | Search → hydrate → rerank → ground → cite → inject |
 | litellm | `ghcr.io/berriai/litellm:main-stable` | 4000 | OpenAI-compatible proxy |
 | open-webui | `ghcr.io/open-webui/open-webui:v0.8.12` | 3000 | Chat UI, pinned to v0.8.12 |
@@ -69,7 +69,7 @@ cp ragstack.env.example ~/.config/llm-stack/ragstack.env
   deps            install system packages via dnf
   groups          add user to render/video groups
   setup           verify GPU, configure dirs
-  pull-image      pull RamaLama ROCm image (with registry fallback)
+  pull-image      pull llama-vulkan container image from GHCR
   pull-models     download model
   install         install quadlets + enable on boot
   up              start all services


### PR DESCRIPTION
Documentation update based on issues and PRs merged since last audit.

Key changes:
- llama-vulkan replaces ramalama at port 8080 (Vulkan RADV on gfx1151)
- MXR cache: cold start ~3:53, warm start ~6s (39x improvement) via ORT_MIGRAPHX_MODEL_CACHE_PATH
- GPU: Vulkan RADV for LLM inference, CPU for embedder/reranker on gfx1151
- Container images: GHCR for ragstuffer, ragwatch, ragdeck (not localhost)
- ragdeck port corrected: 8092 (was 8095)
- ragstuffer-mpep documented at port 8093
- Health checks updated with all service ports
- Known issues updated: cold start, CPU on gfx1151, Vulkan required
- CLAUDE.md updated with all port corrections and llama-vulkan

Closes #39 (llama-vulkan CI)
Closes #38 (ragstuffer GHCR image)
Closes #36 (RAGPIPE_MXR_CACHE)
Closes #34 (ReadOnlyRootfs)
Closes #30 (Vulkan UBI container)
Refs #19 (ragdeck quadlet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ragstuffer-mpep and ragdeck services (Admin UI) to the RAG pipeline stack.

* **Documentation**
  * Replaced ROCm/MIGraphX-specific guidance with Vulkan (llama-vulkan) requirements and updated cold/warm start timing, embedder/reranker, and platform notes.
  * Updated RAG pipeline and model routing descriptions to reflect the llama-vulkan inference backend.

* **Chores**
  * Switched container image references to published GHCR images across the stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->