### PR TITLE
feat(framework-ai-stack): add ragorchestrator quadlet (fixes #43)

### DIFF
--- a/quadlets/ragorchestrator.container
+++ b/quadlets/ragorchestrator.container
@@ -1,0 +1,42 @@
+# ~/.config/containers/systemd/ragorchestrator.container
+# ragorchestrator — LangGraph supervisor agent for ragpipe
+# Source: https://github.com/aclater/ragorchestrator
+# Managed by: systemctl --user [start|stop|restart|status] ragorchestrator
+
+[Unit]
+Description=ragorchestrator (LangGraph supervisor agent for agentic RAG)
+After=local-fs.target network-online.target ragpipe.service
+Wants=network-online.target
+Requires=ragpipe.service
+
+[Container]
+Image=ghcr.io/aclater/ragorchestrator:main
+
+# Run as non-root user (default in UBI Python images, UID 1001)
+User=1001
+
+Environment=RAGPIPE_URL=http://host.containers.internal:8090
+Environment=RAGORCHESTRATOR_PORT=8095
+
+# Credentials sourced from ragstack.env — never committed to the repo
+# Provides: RAGPIPE_ADMIN_TOKEN
+EnvironmentFile=%h/.config/llm-stack/ragstack.env
+
+Network=host
+
+ContainerName=ragorchestrator
+
+# Health check
+HealthCmd=curl -sf http://127.0.0.1:8095/health
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=30s
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=120s
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #43

## Change
Added ragorchestrator quadlet for systemd integration. The quadlet:
- Connects to ragpipe.service as dependency
- Exposes port 8095 for agentic RAG queries
- Uses ragstack.env for RAGPIPE_ADMIN_TOKEN
- Includes health check at /health endpoint

## Testing
- Created quadlet following existing patterns in quadlets/ directory
- Follows same structure as ragpipe.container and other services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added ragorchestrator service with integrated health monitoring and automatic service management
* Service includes automatic restart capabilities, upstream integration, and secure credential handling
* Configured with proper dependency management and network integration for reliable operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->