### PR TITLE
Migrate quadlet healthchecks from curl to Python urllib (fixes #61)

### DIFF
--- a/hosts/gfx1151/quadlets/llama-vulkan.container
+++ b/hosts/gfx1151/quadlets/llama-vulkan.container
@@ -46,7 +46,7 @@ Exec=--model /mnt/models/model.file --host 0.0.0.0 --port 8080 \
 ContainerName=llama-vulkan
 PublishPort=8080:8080
 
-HealthCmd=curl -sf http://127.0.0.1:8080/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/hosts/nvidia/quadlets/ramalama.container
+++ b/hosts/nvidia/quadlets/ramalama.container
@@ -32,7 +32,7 @@ Exec=llama-server --model /mnt/models/model.file --host 0.0.0.0 --port 8080 \
 ContainerName=ramalama
 PublishPort=8080:8080
 
-HealthCmd=curl -sf http://127.0.0.1:8080/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/hosts/nvidia/quadlets/saullm.container
+++ b/hosts/nvidia/quadlets/saullm.container
@@ -35,7 +35,7 @@ Exec=llama-server --model /mnt/models/model.file --host 0.0.0.0 --port 8081 \
 ContainerName=saullm
 PublishPort=8081:8081
 
-HealthCmd=curl -sf http://127.0.0.1:8081/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/quadlets/ragdeck.container
+++ b/quadlets/ragdeck.container
@@ -24,7 +24,7 @@ Environment=QDRANT_URL=http://host.containers.internal:6333
 EnvironmentFile=%h/.config/llm-stack/ragstack.env
 
 # Health check
-HealthCmd=curl -sf http://127.0.0.1:8092/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8092/health')"
 HealthInterval=30s
 HealthTimeout=5s
 HealthRetries=3

--- a/quadlets/ragpipe.container
+++ b/quadlets/ragpipe.container
@@ -73,7 +73,7 @@ Network=host
 ContainerName=ragpipe
 
 # Health check
-HealthCmd=curl -sf http://127.0.0.1:8090/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/quadlets/ragstuffer-mpep.container
+++ b/quadlets/ragstuffer-mpep.container
@@ -34,7 +34,7 @@ Network=host
 
 ContainerName=ragstuffer-mpep
 
-HealthCmd=curl -sf http://127.0.0.1:8093/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8093/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/quadlets/ragstuffer.container
+++ b/quadlets/ragstuffer.container
@@ -37,7 +37,7 @@ Network=host
 
 ContainerName=ragstuffer
 
-HealthCmd=curl -sf http://127.0.0.1:8091/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8091/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3

--- a/quadlets/ragwatch.container
+++ b/quadlets/ragwatch.container
@@ -18,7 +18,7 @@ PublishPort=9090:9090
 EnvironmentFile=%h/.config/llm-stack/ragstack.env
 
 # Health check
-HealthCmd=curl -sf http://127.0.0.1:9090/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9090/health')"
 HealthInterval=30s
 HealthTimeout=5s
 HealthRetries=3

--- a/quadlets/ramalama.container
+++ b/quadlets/ramalama.container
@@ -46,7 +46,7 @@ Exec=llama-server --model /mnt/models/model.file --host 0.0.0.0 --port 8080 \
 ContainerName=ramalama
 PublishPort=8080:8080
 
-HealthCmd=curl -sf http://127.0.0.1:8080/health
+HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')"
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=3


### PR DESCRIPTION
Closes #61

## Problem
9 quadlet files use `curl -sf` in HealthCmd, but UBI10-minimal does not include curl. This causes healthchecks to fail silently on UBI10-minimal base images.

## Solution
Replace all curl-based HealthCmd with Python urllib.request:
```ini
HealthCmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:<port>/health')"
```

9 files changed, matching the pattern used by ragorchestrator.container and open-webui.container (which already use Python healthchecks).

## Testing
- 87 shell tests passing (including `check_no_curl_in_healthcmd` validator)
- `grep -r "HealthCmd=curl" quadlets/ hosts/` returns no matches

## Verification
```bash
grep -r "curl" quadlets/ hosts/ | grep -i healthcmd
# Expected: no output
```