### PR TITLE
feat(ci): add SBOM attestation to container build workflow (fixes #65)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io
@@ -68,6 +70,7 @@ jobs:
             type=raw,value=${{ steps.tag.outputs.llama_tag }}
 
       - name: Build (PR) / Build & push (main/tag)
+        id: build
         uses: docker/build-push-action@v7.0.0
         with:
           context: containers/llama-vulkan
@@ -75,3 +78,30 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate SBOM
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attest SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          predicate-type: https://spdx.dev/Document
+          predicate-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Upload SBOM artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: sbom-llama-vulkan-${{ github.run_id }}
+          path: sbom.spdx.json
+          retention-days: 90


### PR DESCRIPTION
Closes #65

## Summary
- Added `anchore/sbom-action@v0.24.0` to generate SPDX-JSON SBOM after container build
- Added `actions/attest@v4.1.0` to cryptographically attest the SBOM and push attestation to GHCR
- Added `actions/upload-artifact@v7.0.0` to upload SBOM as build artifact (90-day retention)
- Added `id-token: write` and `attestations: write` permissions required for signing
- All three steps only run on push to main/tags (skipped on PRs)

## Test plan
- [x] All 87 local tests pass (`bash tests/run-tests.sh`)
- [ ] CI validates YAML syntax and workflow structure
- [ ] On merge to main, verify SBOM artifact appears in workflow run
- [ ] Verify attestation is pushed to GHCR (`gh attestation verify`)

## Action versions (verified via API)
- `anchore/sbom-action@v0.24.0`
- `actions/attest@v4.1.0` (NOT deprecated `actions/attest-sbom`)
- `actions/upload-artifact@v7.0.0`

## Reference
Pattern matches ragpipe's container.yml SBOM attestation steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)