### PR TITLE
docs: update architecture.svg with full 11-container topology

### DIFF
--- a/architecture.svg
+++ b/architecture.svg
@@ -1,4 +1,4 @@
-<svg width="100%" viewBox="0 0 780 660" xmlns="http://www.w3.org/2000/svg" style="font-family:system-ui,sans-serif;background:transparent">
+<svg width="100%" viewBox="0 0 960 820" xmlns="http://www.w3.org/2000/svg" style="font-family:system-ui,sans-serif;background:transparent">
 
 <defs>
   <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -6,9 +6,10 @@
   </marker>
   <style>
     text { fill: #2C2C2A; }
-    .th  { font-size:14px; font-weight:600; }
-    .ts  { font-size:12px; font-weight:400; }
-    .tl  { font-size:11px; font-weight:400; }
+    .th  { font-size:13px; font-weight:600; }
+    .ts  { font-size:11px; font-weight:400; }
+    .tl  { font-size:10px; font-weight:400; }
+    .txs { font-size:9px;  font-weight:400; }
     .c-gray-fill    { fill:#F1EFE8; stroke:#5F5E5A; }
     .c-purple-fill  { fill:#EEEDFE; stroke:#534AB7; }
     .c-teal-fill    { fill:#E1F5EE; stroke:#0F6E56; }
@@ -17,6 +18,7 @@
     .c-green-fill   { fill:#EAF3DE; stroke:#3B6D11; }
     .c-sand-fill    { fill:#F5F0E0; stroke:#8B7D56; }
     .c-amber-fill   { fill:#FEF3CD; stroke:#B8860B; }
+    .c-rose-fill    { fill:#FDE8E8; stroke:#B91C1C; }
     .c-gray-text    { fill:#444441; }
     .c-purple-text  { fill:#3C3489; }
     .c-teal-text    { fill:#085041; }
@@ -25,7 +27,9 @@
     .c-green-text   { fill:#27500A; }
     .c-sand-text    { fill:#5C512E; }
     .c-amber-text   { fill:#6B4C00; }
+    .c-rose-text    { fill:#7F1D1D; }
     .muted          { fill:#888780; }
+    .gpu-badge      { fill:#0F6E56; }
     @media (prefers-color-scheme:dark) {
       text              { fill:#D3D1C7; }
       .c-gray-fill      { fill:#444441; stroke:#B4B2A9; }
@@ -36,6 +40,7 @@
       .c-green-fill     { fill:#27500A; stroke:#97C459; }
       .c-sand-fill      { fill:#4A4328; stroke:#C4B882; }
       .c-amber-fill     { fill:#4A3800; stroke:#D4A017; }
+      .c-rose-fill      { fill:#5C1515; stroke:#F87171; }
       .c-gray-text      { fill:#D3D1C7; }
       .c-purple-text    { fill:#CECBF6; }
       .c-teal-text      { fill:#9FE1CB; }
@@ -44,118 +49,235 @@
       .c-green-text     { fill:#C0DD97; }
       .c-sand-text      { fill:#D8CFA0; }
       .c-amber-text     { fill:#E8C84A; }
+      .c-rose-text      { fill:#FCA5A5; }
       .muted            { fill:#B4B2A9; }
+      .gpu-badge        { fill:#5DCAA5; }
     }
   </style>
 </defs>
 
-<!-- Column headers -->
-<text class="ts muted" x="210" y="14" text-anchor="middle" dominant-baseline="central">Inference</text>
-<text class="ts muted" x="590" y="14" text-anchor="middle" dominant-baseline="central">RAG pipeline</text>
+<!-- ================================================================== -->
+<!-- LEGEND                                                              -->
+<!-- ================================================================== -->
+<rect x="740" y="8" width="12" height="12" rx="2" class="c-teal-fill" stroke-width="0.5"/>
+<text class="txs muted" x="756" y="18">GPU container</text>
+<rect x="840" y="8" width="12" height="12" rx="2" class="c-gray-fill" stroke-width="0.5"/>
+<text class="txs muted" x="856" y="18">CPU container</text>
+<rect x="740" y="24" width="12" height="12" rx="2" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="txs muted" x="756" y="34">volume mount</text>
 
-<!-- Client tier -->
-<rect x="30" y="28" width="360" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
-<text class="th c-gray-text" x="210" y="52" text-anchor="middle" dominant-baseline="central">Claude Code · Open WebUI · clients</text>
+<!-- ================================================================== -->
+<!-- COLUMN HEADERS                                                     -->
+<!-- ================================================================== -->
+<text class="ts muted" x="240" y="14" text-anchor="middle">Inference + Orchestration</text>
+<text class="ts muted" x="680" y="14" text-anchor="middle">RAG pipeline + Ingestion</text>
 
-<!-- Document sources -->
-<rect x="420" y="28" width="340" height="48" rx="8" stroke-width="0.5" class="c-sand-fill"/>
-<text class="th c-sand-text" x="590" y="44" text-anchor="middle" dominant-baseline="central">Document sources</text>
-<text class="ts c-sand-text" x="590" y="62" text-anchor="middle" dominant-baseline="central">Google Drive · git repos · web URLs</text>
+<!-- ================================================================== -->
+<!-- ROW 1: Client tier + Document sources                              -->
+<!-- ================================================================== -->
+<rect x="30" y="32" width="420" height="44" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="240" y="54" text-anchor="middle" dominant-baseline="central">Claude Code  /  Open WebUI  /  curl  /  clients</text>
 
-<!-- Arrow client → LiteLLM -->
-<line x1="210" y1="76" x2="210" y2="106" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
-<text class="ts muted" x="225" y="93" dominant-baseline="central">:4000</text>
+<rect x="480" y="32" width="450" height="44" rx="8" stroke-width="0.5" class="c-sand-fill"/>
+<text class="th c-sand-text" x="705" y="46" text-anchor="middle" dominant-baseline="central">Document sources</text>
+<text class="ts c-sand-text" x="705" y="64" text-anchor="middle" dominant-baseline="central">Google Drive  /  git repos  /  web URLs</text>
 
-<!-- Arrow sources → watcher -->
-<line x1="590" y1="76" x2="590" y2="106" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<!-- Arrow client -> LiteLLM -->
+<line x1="240" y1="76" x2="240" y2="102" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="254" y="92">:4000</text>
 
-<!-- LiteLLM proxy -->
-<rect x="30" y="108" width="360" height="52" rx="8" stroke-width="0.5" class="c-purple-fill"/>
-<text class="th c-purple-text" x="210" y="128" text-anchor="middle" dominant-baseline="central">LiteLLM proxy</text>
-<text class="ts c-purple-text" x="210" y="146" text-anchor="middle" dominant-baseline="central">default · reasoning · code · fast → :8090</text>
+<!-- Arrow sources -> ragstuffer -->
+<line x1="640" y1="76" x2="640" y2="102" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<line x1="770" y1="76" x2="770" y2="102" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
 
-<!-- ragstuffer -->
-<rect x="420" y="108" width="340" height="52" rx="8" stroke-width="0.5" class="c-sand-fill"/>
-<text class="th c-sand-text" x="590" y="128" text-anchor="middle" dominant-baseline="central">ragstuffer</text>
-<text class="ts c-sand-text" x="590" y="146" text-anchor="middle" dominant-baseline="central">extract · chunk · embed · persist</text>
+<!-- ================================================================== -->
+<!-- ROW 2: LiteLLM + ragstuffers                                       -->
+<!-- ================================================================== -->
+<rect x="30" y="104" width="420" height="48" rx="8" stroke-width="0.5" class="c-purple-fill"/>
+<text class="th c-purple-text" x="240" y="122" text-anchor="middle" dominant-baseline="central">LiteLLM proxy  :4000</text>
+<text class="ts c-purple-text" x="240" y="140" text-anchor="middle" dominant-baseline="central">model aliases: default / reasoning / code / fast</text>
 
-<!-- Arrow LiteLLM → ragpipe -->
-<line x1="210" y1="160" x2="210" y2="190" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
-<text class="ts muted" x="225" y="177" dominant-baseline="central">:8090</text>
+<!-- ragstuffer :8091 -->
+<rect x="480" y="104" width="218" height="48" rx="8" stroke-width="0.5" class="c-sand-fill"/>
+<text class="th c-sand-text" x="589" y="122" text-anchor="middle" dominant-baseline="central">ragstuffer  :8091</text>
+<text class="ts c-sand-text" x="589" y="140" text-anchor="middle" dominant-baseline="central">extract / chunk / embed / persist</text>
 
-<!-- Arrow watcher → Qdrant -->
-<line x1="540" y1="160" x2="540" y2="190" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
-<text class="tl muted" x="540" y="177" text-anchor="middle" dominant-baseline="central">vectors</text>
+<!-- ragstuffer-mpep :8093 -->
+<rect x="712" y="104" width="218" height="48" rx="8" stroke-width="0.5" class="c-sand-fill"/>
+<text class="th c-sand-text" x="821" y="122" text-anchor="middle" dominant-baseline="central">ragstuffer-mpep  :8093</text>
+<text class="ts c-sand-text" x="821" y="140" text-anchor="middle" dominant-baseline="central">USPTO / MPEP collection</text>
 
-<!-- Arrow watcher → docstore -->
-<line x1="640" y1="160" x2="640" y2="190" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
-<text class="tl muted" x="640" y="177" text-anchor="middle" dominant-baseline="central">text</text>
+<!-- Arrow LiteLLM -> ragorchestrator -->
+<line x1="240" y1="152" x2="240" y2="178" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="254" y="168">:8095</text>
 
-<!-- ragpipe box (taller to show full pipeline) -->
-<rect x="30" y="192" width="360" height="118" rx="8" stroke-width="0.5" class="c-coral-fill"/>
-<text class="th c-coral-text" x="210" y="210" text-anchor="middle" dominant-baseline="central">ragpipe</text>
-<text class="ts c-coral-text" x="210" y="228" text-anchor="middle" dominant-baseline="central">1. Qdrant vector search (40 candidates)</text>
-<text class="ts c-coral-text" x="210" y="244" text-anchor="middle" dominant-baseline="central">2. Docstore hydration (batch text lookup)</text>
-<text class="ts c-coral-text" x="210" y="260" text-anchor="middle" dominant-baseline="central">3. Cross-encoder reranker (MiniLM) → top 15</text>
-<text class="ts c-coral-text" x="210" y="276" text-anchor="middle" dominant-baseline="central">4. Grounding prompt + [doc_id:chunk_id] labels</text>
-<text class="ts c-coral-text" x="210" y="292" text-anchor="middle" dominant-baseline="central">5. Post-response: cite → validate → classify → audit</text>
+<!-- Arrow ragstuffers -> Qdrant -->
+<line x1="560" y1="152" x2="560" y2="290" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="563" y="230">vectors</text>
+
+<!-- Arrow ragstuffers -> Postgres -->
+<line x1="700" y1="152" x2="700" y2="290" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="703" y="230">text</text>
+
+<!-- Arrow ragstuffer-mpep -> Qdrant -->
+<line x1="780" y1="152" x2="780" y2="268" stroke="#888780" stroke-width="0.8"/>
+<line x1="780" y1="268" x2="590" y2="268" stroke="#888780" stroke-width="0.8"/>
+<line x1="590" y1="268" x2="590" y2="290" stroke="#888780" stroke-width="0.8" marker-end="url(#arrow)"/>
+
+<!-- Arrow ragstuffer-mpep -> Postgres -->
+<line x1="860" y1="152" x2="860" y2="278" stroke="#888780" stroke-width="0.8"/>
+<line x1="860" y1="278" x2="730" y2="278" stroke="#888780" stroke-width="0.8"/>
+<line x1="730" y1="278" x2="730" y2="290" stroke="#888780" stroke-width="0.8" marker-end="url(#arrow)"/>
+
+<!-- ================================================================== -->
+<!-- ROW 3: ragorchestrator                                             -->
+<!-- ================================================================== -->
+<rect x="30" y="180" width="420" height="48" rx="8" stroke-width="0.5" class="c-rose-fill"/>
+<text class="th c-rose-text" x="240" y="198" text-anchor="middle" dominant-baseline="central">ragorchestrator  :8095</text>
+<text class="ts c-rose-text" x="240" y="216" text-anchor="middle" dominant-baseline="central">LangGraph  /  complexity classify  /  Self-RAG  /  multi-pass</text>
+
+<!-- Arrow ragorchestrator -> ragpipe -->
+<line x1="240" y1="228" x2="240" y2="258" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="254" y="246">:8090</text>
+
+<!-- ================================================================== -->
+<!-- ROW 4: ragpipe (GPU) + data stores                                 -->
+<!-- ================================================================== -->
+<!-- ragpipe box -->
+<rect x="30" y="260" width="420" height="110" rx="8" stroke-width="0.5" class="c-coral-fill"/>
+<text class="th c-coral-text" x="240" y="278" text-anchor="middle" dominant-baseline="central">ragpipe  :8090</text>
+<text class="txs gpu-badge" x="340" y="278" dominant-baseline="central">GPU /dev/kfd /dev/dri</text>
+<text class="ts c-coral-text" x="240" y="296" text-anchor="middle" dominant-baseline="central">1. Qdrant vector search (40 candidates)</text>
+<text class="ts c-coral-text" x="240" y="312" text-anchor="middle" dominant-baseline="central">2. Docstore hydration (batch text lookup)</text>
+<text class="ts c-coral-text" x="240" y="328" text-anchor="middle" dominant-baseline="central">3. Cross-encoder reranker (MiniLM-L-6-v2) top 15</text>
+<text class="ts c-coral-text" x="240" y="344" text-anchor="middle" dominant-baseline="central">4. Grounding prompt + [doc_id:chunk_id] labels</text>
+<text class="ts c-coral-text" x="240" y="360" text-anchor="middle" dominant-baseline="central">5. Post-response: cite / validate / classify / audit</text>
 
 <!-- Qdrant -->
-<rect x="420" y="192" width="165" height="60" rx="8" stroke-width="0.5" class="c-blue-fill"/>
-<text class="th c-blue-text" x="502" y="214" text-anchor="middle" dominant-baseline="central">Qdrant</text>
-<text class="ts c-blue-text" x="502" y="234" text-anchor="middle" dominant-baseline="central">int8 quantized · :6333</text>
+<rect x="480" y="292" width="200" height="56" rx="8" stroke-width="0.5" class="c-blue-fill"/>
+<text class="th c-blue-text" x="580" y="312" text-anchor="middle" dominant-baseline="central">Qdrant  :6333</text>
+<text class="ts c-blue-text" x="580" y="332" text-anchor="middle" dominant-baseline="central">int8 quantized  /  4 collections</text>
 
-<!-- Docstore (Postgres) -->
-<rect x="595" y="192" width="165" height="60" rx="8" stroke-width="0.5" class="c-amber-fill"/>
-<text class="th c-amber-text" x="677" y="214" text-anchor="middle" dominant-baseline="central">Document store</text>
-<text class="ts c-amber-text" x="677" y="234" text-anchor="middle" dominant-baseline="central">Postgres · :5432</text>
+<!-- Postgres -->
+<rect x="700" y="292" width="230" height="56" rx="8" stroke-width="0.5" class="c-amber-fill"/>
+<text class="th c-amber-text" x="815" y="312" text-anchor="middle" dominant-baseline="central">Postgres  :5432</text>
+<text class="ts c-amber-text" x="815" y="332" text-anchor="middle" dominant-baseline="central">docstore + LiteLLM state</text>
 
-<!-- Arrow ragpipe → Qdrant -->
-<line x1="390" y1="222" x2="418" y2="222" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<!-- Arrow ragpipe -> Qdrant -->
+<line x1="450" y1="310" x2="478" y2="310" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
 
-<!-- Arrow ragpipe → docstore -->
-<line x1="390" y1="244" x2="593" y2="244" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<!-- Arrow ragpipe -> Postgres -->
+<line x1="450" y1="330" x2="698" y2="330" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
 
-<!-- Arrow ragpipe → model -->
-<line x1="210" y1="310" x2="210" y2="346" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
-<text class="ts muted" x="225" y="330" dominant-baseline="central">:8080</text>
+<!-- Arrow ragpipe -> model -->
+<line x1="240" y1="370" x2="240" y2="404" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<text class="tl muted" x="254" y="390">:8080</text>
 
-<!-- RamaLama dashed container -->
-<rect x="24" y="332" width="378" height="120" rx="6" fill="none" stroke-dasharray="4 3" stroke-width="0.5" stroke="#888780"/>
-<text class="tl muted" x="37" y="325" dominant-baseline="central">RamaLama · auto-tuned (see tune.conf)</text>
+<!-- ================================================================== -->
+<!-- ROW 5: llama-vulkan (GPU)                                          -->
+<!-- ================================================================== -->
+<!-- RamaLama dashed wrapper -->
+<rect x="24" y="390" width="432" height="108" rx="6" fill="none" stroke-dasharray="4 3" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="37" y="386">RamaLama  /  auto-tuned (tune.conf)</text>
 
-<!-- Qwen model -->
-<rect x="42" y="346" width="344" height="92" rx="8" stroke-width="0.5" class="c-teal-fill"/>
-<text class="th c-teal-text" x="214" y="370" text-anchor="middle" dominant-baseline="central">Qwen3.5-35B-A3B</text>
-<text class="ts c-teal-text" x="214" y="392" text-anchor="middle" dominant-baseline="central">model + quant selected by auto-tuner</text>
-<text class="ts c-teal-text" x="214" y="412" text-anchor="middle" dominant-baseline="central">flash attn · ctx + slots from tune.conf</text>
+<rect x="42" y="406" width="400" height="80" rx="8" stroke-width="0.5" class="c-teal-fill"/>
+<text class="th c-teal-text" x="242" y="428" text-anchor="middle" dominant-baseline="central">llama-vulkan  :8080</text>
+<text class="txs gpu-badge" x="370" y="428" dominant-baseline="central">GPU /dev/kfd /dev/dri</text>
+<text class="ts c-teal-text" x="242" y="448" text-anchor="middle" dominant-baseline="central">Qwen3-32B dense Q4_K_M  /  ~19 GB GTT</text>
+<text class="ts c-teal-text" x="242" y="466" text-anchor="middle" dominant-baseline="central">Vulkan RADV  /  flash attn  /  ctx from tune.conf</text>
 
-<!-- Arrow model → GPU -->
-<line x1="210" y1="452" x2="210" y2="482" stroke="#888780" stroke-width="1" marker-end="url(#arrow)"/>
+<!-- ================================================================== -->
+<!-- ROW 6: Monitoring + Admin                                          -->
+<!-- ================================================================== -->
+<!-- ragwatch -->
+<rect x="480" y="380" width="200" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="580" y="398" text-anchor="middle" dominant-baseline="central">ragwatch  :9090</text>
+<text class="ts c-gray-text" x="580" y="416" text-anchor="middle" dominant-baseline="central">Prometheus aggregation</text>
 
-<!-- GPU layer -->
-<rect x="30" y="484" width="730" height="56" rx="8" stroke-width="0.5" class="c-green-fill"/>
-<text class="th c-green-text" x="395" y="506" text-anchor="middle" dominant-baseline="central">AMD Ryzen AI Max+ 395 · gfx1151 · ROCm</text>
-<text class="ts c-green-text" x="395" y="526" text-anchor="middle" dominant-baseline="central">64 GB VRAM + 64 GB GTT · 62 GB system RAM</text>
+<!-- ragdeck -->
+<rect x="700" y="380" width="230" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="815" y="398" text-anchor="middle" dominant-baseline="central">ragdeck  :8092</text>
+<text class="ts c-gray-text" x="815" y="416" text-anchor="middle" dominant-baseline="central">admin UI (FastAPI + frontend)</text>
 
-<!-- Separator -->
-<line x1="30" y1="560" x2="760" y2="560" stroke-dasharray="3 3" stroke-width="0.5" stroke="#888780"/>
+<!-- ragwatch scrapes ragpipe -->
+<line x1="480" y1="404" x2="450" y2="340" stroke="#888780" stroke-width="0.8" stroke-dasharray="3 2" marker-end="url(#arrow)"/>
+<text class="txs muted" x="458" y="368">scrapes /metrics</text>
 
-<!-- Bottom row -->
-<rect x="30"  y="574" width="170" height="54" rx="8" stroke-width="0.5" class="c-gray-fill"/>
-<text class="th c-gray-text" x="115" y="595" text-anchor="middle" dominant-baseline="central">Open WebUI</text>
-<text class="ts c-gray-text" x="115" y="614" text-anchor="middle" dominant-baseline="central">v0.8.12 · :3000</text>
+<!-- Open WebUI -->
+<rect x="480" y="444" width="200" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="580" y="462" text-anchor="middle" dominant-baseline="central">Open WebUI  :3000</text>
+<text class="ts c-gray-text" x="580" y="480" text-anchor="middle" dominant-baseline="central">v0.8.12  /  chat interface</text>
 
-<rect x="215" y="574" width="170" height="54" rx="8" stroke-width="0.5" class="c-gray-fill"/>
-<text class="th c-gray-text" x="300" y="595" text-anchor="middle" dominant-baseline="central">UBI9 · UBI10</text>
-<text class="ts c-gray-text" x="300" y="614" text-anchor="middle" dominant-baseline="central">SELinux enforcing</text>
+<!-- Open WebUI -> LiteLLM -->
+<line x1="480" y1="462" x2="450" y2="134" stroke="#888780" stroke-width="0.8" stroke-dasharray="3 2"/>
+<text class="txs muted" x="460" y="300">:4000</text>
 
-<rect x="400" y="574" width="175" height="54" rx="8" stroke-width="0.5" class="c-gray-fill"/>
-<text class="th c-gray-text" x="487" y="595" text-anchor="middle" dominant-baseline="central">Fedora 43</text>
-<text class="ts c-gray-text" x="487" y="614" text-anchor="middle" dominant-baseline="central">Podman quadlets</text>
+<!-- ================================================================== -->
+<!-- ROW 7: GPU / Hardware layer                                        -->
+<!-- ================================================================== -->
+<rect x="30" y="520" width="900" height="52" rx="8" stroke-width="0.5" class="c-green-fill"/>
+<text class="th c-green-text" x="480" y="540" text-anchor="middle" dominant-baseline="central">AMD Ryzen AI Max+ 395  /  gfx1151  /  Vulkan RADV + ROCm 7.x</text>
+<text class="ts c-green-text" x="480" y="558" text-anchor="middle" dominant-baseline="central">512 MB VRAM (housekeeping)  /  ~113 GB GTT (model + KV cache + inference)  /  HSA_OVERRIDE_GFX_VERSION=11.5.1</text>
 
-<rect x="590" y="574" width="170" height="54" rx="8" stroke-width="0.5" class="c-gray-fill"/>
-<text class="th c-gray-text" x="675" y="595" text-anchor="middle" dominant-baseline="central">systemd</text>
-<text class="ts c-gray-text" x="675" y="614" text-anchor="middle" dominant-baseline="central">rootless user services</text>
+<!-- ================================================================== -->
+<!-- ROW 8: Volumes                                                     -->
+<!-- ================================================================== -->
+<line x1="30" y1="590" x2="930" y2="590" stroke-dasharray="3 3" stroke-width="0.5" stroke="#888780"/>
+<text class="ts muted" x="30" y="608">Named volumes</text>
+
+<rect x="30"  y="616" width="150" height="40" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="105" y="632" text-anchor="middle">ragpipe-model-cache</text>
+<text class="txs muted" x="105" y="646" text-anchor="middle">MXR + ONNX models</text>
+
+<rect x="195" y="616" width="120" height="40" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="255" y="632" text-anchor="middle">qdrant-data</text>
+<text class="txs muted" x="255" y="646" text-anchor="middle">vector storage</text>
+
+<rect x="330" y="616" width="120" height="40" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="390" y="632" text-anchor="middle">litellm-db-data</text>
+<text class="txs muted" x="390" y="646" text-anchor="middle">LiteLLM state</text>
+
+<rect x="465" y="616" width="130" height="40" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="530" y="632" text-anchor="middle">open-webui-data</text>
+<text class="txs muted" x="530" y="646" text-anchor="middle">chat history</text>
+
+<rect x="610" y="616" width="110" height="40" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="665" y="632" text-anchor="middle">rag-staging</text>
+<text class="txs muted" x="665" y="646" text-anchor="middle">ingestion scratch</text>
+
+<!-- ================================================================== -->
+<!-- ROW 9: Host config mounts                                          -->
+<!-- ================================================================== -->
+<text class="ts muted" x="30" y="680">Host config mounts (hot-reloadable)</text>
+
+<rect x="30"  y="690" width="240" height="34" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="150" y="711" text-anchor="middle">~/.config/ragpipe/routes.yaml</text>
+
+<rect x="285" y="690" width="260" height="34" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="415" y="711" text-anchor="middle">~/.config/ragpipe/system-prompt.txt</text>
+
+<rect x="560" y="690" width="260" height="34" rx="6" fill="none" stroke-dasharray="3 2" stroke-width="0.5" stroke="#888780"/>
+<text class="tl muted" x="690" y="711" text-anchor="middle">~/.config/llm-stack/litellm-config.yaml</text>
+
+<!-- ================================================================== -->
+<!-- ROW 10: Platform footer                                            -->
+<!-- ================================================================== -->
+<line x1="30" y1="740" x2="930" y2="740" stroke-dasharray="3 3" stroke-width="0.5" stroke="#888780"/>
+
+<rect x="30"  y="754" width="210" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="135" y="772" text-anchor="middle" dominant-baseline="central">Fedora 43</text>
+<text class="ts c-gray-text" x="135" y="792" text-anchor="middle" dominant-baseline="central">Podman quadlets  /  rootless</text>
+
+<rect x="260" y="754" width="210" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="365" y="772" text-anchor="middle" dominant-baseline="central">systemd</text>
+<text class="ts c-gray-text" x="365" y="792" text-anchor="middle" dominant-baseline="central">user services  /  dependency chain</text>
+
+<rect x="490" y="754" width="210" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="595" y="772" text-anchor="middle" dominant-baseline="central">SELinux enforcing</text>
+<text class="ts c-gray-text" x="595" y="792" text-anchor="middle" dominant-baseline="central">UBI9 / UBI10 base images</text>
+
+<rect x="720" y="754" width="210" height="48" rx="8" stroke-width="0.5" class="c-gray-fill"/>
+<text class="th c-gray-text" x="825" y="772" text-anchor="middle" dominant-baseline="central">128 GB unified memory</text>
+<text class="ts c-gray-text" x="825" y="792" text-anchor="middle" dominant-baseline="central">APU  /  GTT-backed inference</text>
 
 </svg>


### PR DESCRIPTION
## Summary

- Replaces outdated architecture.svg with accurate diagram of all 11 quadlet containers
- Shows ragorchestrator as the LangGraph agentic layer between LiteLLM and ragpipe
- Dual ragstuffer instances (ragstuffer :8091 + ragstuffer-mpep :8093) with data flow arrows
- GPU containers (ragpipe, llama-vulkan) visually marked with `/dev/kfd /dev/dri` badge
- All 5 named volumes: ragpipe-model-cache, qdrant-data, litellm-db-data, open-webui-data, rag-staging
- Host config mounts: routes.yaml, system-prompt.txt, litellm-config.yaml
- Hardware layer: gfx1151, Vulkan RADV, ~113 GB GTT, HSA_OVERRIDE_GFX_VERSION
- Dark/light mode compatible via `prefers-color-scheme` media query
- 960px wide viewBox for readability

## Test plan

- [x] `bash tests/run-tests.sh` -- all 87 tests pass (includes SVG validation: exists, viewBox, LiteLLM, ROCm, port 8080, dark mode, valid XML)
- [ ] Visual review: check rendering on GitHub in both light and dark mode

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)